### PR TITLE
Outputting results according to types recognized by PDO

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,6 +32,21 @@ pdo-cli > select 1,2,3;
 +---+---+---+
 ```
 
+## Output
+
+You can also check what type PDO recognizes each column as with the `--output-as-pdo-type` option.
+
+In that case, the output will be JSON, for example:
+
+```
+pdo-cli > select 1, '2', true;
++---+-----+------+
+| 1 | 2   | true |
++---+-----+------+
+| 1 | "2" | 1    |
++---+-----+------+
+```
+
 ## Close
 
 There are MySQL-like command and PostgreSQL-like command.

--- a/pdo-cli
+++ b/pdo-cli
@@ -4,22 +4,27 @@
 global $db;
 
 $configSuffix = null;
-if (isset($argv[1])) {
-    preg_match('/^--config-(.*)$/', $argv[1], $matches);
-    $configSuffix = $matches[1];
-} else {
-    $configSuffix = null;
+$shouldOutputAsPDOType = false;
+foreach(array_slice($argv, 1) as $arg) {
+    if (preg_match('/^--config-(.*)$/', $arg, $matches)) {
+        $configSuffix = $matches[1];
+        continue;
+    }
+    if ($arg === '--output-as-pdo-type') {
+        $shouldOutputAsPDOType = true;
+        continue;
+    }
 }
 
 require_once __DIR__ . '/src/init.php';
 require_once __DIR__ . '/src/shell.php';
 
 try {
-    $db = init($configSuffix);
+    $db = init($configSuffix, $shouldOutputAsPDOType);
 
     echo "--------------- pdo-cli (c) Saki Takamachi ---------------\n\n";
     
-    main();
+    main($shouldOutputAsPDOType);
 } catch (Exception $e) {
     die($e->getMessage()."\n");
 }

--- a/src/init.php
+++ b/src/init.php
@@ -1,6 +1,6 @@
 <?php
 
-function init(?string $configSuffix): PDO
+function init(?string $configSuffix, bool $shouldOutputAsPDOType): PDO
 {
     if (! extension_loaded('pdo')) {
         throw new Exception('PDO extension is not loaded');
@@ -20,7 +20,7 @@ function init(?string $configSuffix): PDO
     try {
         $db = new PDO($connection['db_type'].':'.$connection['dsn'], $connection['username'] ?? null, $connection['password'] ?? null, [
             PDO::ATTR_ERRMODE => PDO::ERRMODE_EXCEPTION,
-            PDO::ATTR_STRINGIFY_FETCHES => true,
+            PDO::ATTR_STRINGIFY_FETCHES => !$shouldOutputAsPDOType,
         ]);
         if (! $db) die("No connection\n");
     } catch (PDOException $e) {

--- a/src/query_handle.php
+++ b/src/query_handle.php
@@ -92,7 +92,7 @@ function parseResult(array $columns, array $types, array $resultSet, bool $shoul
     echo "\n\n";
 }
 
-function generateJsonValue ($value, ?int $type): string
+function generateJsonValue($value, ?int $type): string
 {
     return json_encode(match ($type) {
         PDO::PARAM_BOOL => boolval($value),

--- a/src/query_handle.php
+++ b/src/query_handle.php
@@ -96,7 +96,6 @@ function generateJsonValue($value, ?int $type): string
 {
     return json_encode(match ($type) {
         PDO::PARAM_BOOL => boolval($value),
-        PDO::PARAM_NULL => null,
         PDO::PARAM_INT => intval($value),
         default => $value,
     });

--- a/src/shell.php
+++ b/src/shell.php
@@ -2,7 +2,7 @@
 
 require_once __DIR__ . '/query_handle.php';
 
-function main(): void
+function main(bool $shouldOutputAsPDOType): void
 {
     $interactive = 'pdo-cli > ';
 
@@ -18,7 +18,7 @@ function main(): void
             $toExec = $sqls[0];
             $sql = $sqls[1] ?? '';
             
-            exec_sql($toExec);
+            exec_sql($toExec, $shouldOutputAsPDOType);
         }
         echo $interactive;
     }


### PR DESCRIPTION
Hi! That's a great idea tool!

I propose an option `--output-as-pdo-type` in this pull request that allows us to check what type of result PDO returns for each column.

If this option is specified, the result will be retrieved according to the `pdo_type` value provided by `getColumnMeta()` and then output as a JSON value. For example:

```
php ./pdo-cli --output-as-pdo-type --config-mysql
--------------- pdo-cli (c) Saki Takamachi ---------------

pdo-cli > select 1, '2', true;
+---+-----+------+
| 1 | 2   | true |
+---+-----+------+
| 1 | "2" | 1    |
+---+-----+------+

pdo-cli > quit
Bye.

$ php ./pdo-cli --output-as-pdo-type --config-pgsql

--------------- pdo-cli (c) Saki Takamachi ---------------

pdo-cli > select 1, '2', true;
+----------+----------+----------+
| ?column? | ?column? | ?column? |
+----------+----------+----------+
| 1        | "2"      | true     |
+----------+----------+----------+
```

Oops, I noticed that the output of boolean values is inconsistent between pgsql and mysql 😅